### PR TITLE
Do not attempt to read SPI bus when imported

### DIFF
--- a/ExpanderPi/ExpanderPi.py
+++ b/ExpanderPi/ExpanderPi.py
@@ -99,10 +99,11 @@ class ADC:
     # variables
     __adcrefvoltage = 4.096  # reference voltage for the ADC chip.
 
-    # Define SPI bus and init
-    __spiADC = spidev.SpiDev()
-    __spiADC.open(0, 0)
-    __spiADC.max_speed_hz = (1900000)
+    def __init__():
+        # Define SPI bus and init
+        __spiADC = spidev.SpiDev()
+        __spiADC.open(0, 0)
+        __spiADC.max_speed_hz = (1900000)
 
     # public methods
 


### PR DESCRIPTION
When importing this library in a project which does **not** use the SPI bus, the library raised an exception on import.
This commit fixes that bug by moving the access to the SPI bus to __init__().